### PR TITLE
Recommend uBlock Origin instead of Adblock Plus

### DIFF
--- a/pages/2016/7.md
+++ b/pages/2016/7.md
@@ -32,7 +32,7 @@ Install the following browser plugins:
 
 - [Privacy Badger](https://www.eff.org/privacybadger)
 - [HTTPS Everywhere](https://www.eff.org/https-everywhere)
-- [Adblock Plus](https://adblockplus.org/)
+- [uBlock Origin](https://github.com/gorhill/uBlock)
 
 ### Bonus
 


### PR DESCRIPTION
ABP is a for-profit company, whereas uBO is open-source.
